### PR TITLE
Updated the RKE2 Version to the latest stable version : v1.24.10+rke2r1

### DIFF
--- a/modules/rke2-agents/variables.tf
+++ b/modules/rke2-agents/variables.tf
@@ -113,7 +113,7 @@ variable "vm_size" {
 }
 
 variable "rke2_version" {
-  default = "v1.21.5+rke2r2"
+  default = "v1.24.10+rke2r1"
 }
 
 variable "tags" {

--- a/modules/rke2-server/variables.tf
+++ b/modules/rke2-server/variables.tf
@@ -104,7 +104,7 @@ variable "vm_size" {
 }
 
 variable "rke2_version" {
-  default = "v1.21.5+rke2r2"
+  default = "v1.24.10+rke2r1"
 }
 
 variable "pre_userdata" {


### PR DESCRIPTION
Issue:

Currently the RKE2 version used in this terraform script is v1.21.5+rke2r2
With this version when we try to do a Flux Bootstrap on the RKE2 we see the below error

E0207 05:26:13.205491       1 replica_set.go:532] sync "flux-system/source-controller-66969f4994" failed with pods "source-controller-66969f4994-" is forbidden: PodSecurityPolicy: unable to admit pod: [pod.metadata.annotations[container.seccomp.security.alpha.kubernetes.io/manager]: Forbidden: seccomp may not be set] E0207 05:26:13.205536       1 replica_set.go:532] sync "flux-system/notification-controller-55cbd85d67" failed with pods "notification-controller-55cbd85d67-" is forbidden: PodSecurityPolicy: unable to admit pod: [pod.metadata.annotations[container.seccomp.security.alpha.kubernetes.io/manager]: Forbidden: seccomp may not be set] E0207 05:26:13.205536       1 replica_set.go:532] sync "flux-system/kustomize-controller-79b77b857f" failed with pods "kustomize-controller-79b77b857f-" is forbidden: PodSecurityPolicy: unable to admit pod: [pod.metadata.annotations[container.seccomp.security.alpha.kubernetes.io/manager]: Forbidden: seccomp may not be set p 

According o this Bug fix : https://repo1.dso.mil/big-bang/bigbang/-/issues/1075 Fix for this was done as part of version v1.22 and above

Updating the RKE2 version in this terraform script fixes the above issue.
https://update.rke2.io/v1-release/channels